### PR TITLE
move mock to unittest since no earily version python support needed

### DIFF
--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -15,7 +15,7 @@ import sysconfig
 from unittest import skip, skipIf, TestCase, TestSuite, findTestCases  # noqa: F401
 
 from tornado.testing import AsyncTestCase
-import mock
+from unittest import mock
 import tornado
 
 from circus import get_arbiter

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -5,7 +5,7 @@ import tornado
 from tempfile import mkstemp
 from time import time
 import zmq.utils.jsonapi as json
-import mock
+from unittest import mock
 from urllib.parse import urlparse
 
 from circus.arbiter import Arbiter

--- a/circus/tests/test_circusctl.py
+++ b/circus/tests/test_circusctl.py
@@ -1,6 +1,6 @@
 import subprocess
 import shlex
-from mock import patch
+from unittest.mock import patch
 from multiprocessing import Process, Queue
 
 from tornado.testing import gen_test

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -1,6 +1,6 @@
 import os
 import signal
-from mock import patch
+from unittest.mock import patch
 
 from circus import logger
 from circus.arbiter import Arbiter

--- a/circus/tests/test_controller.py
+++ b/circus/tests/test_controller.py
@@ -4,7 +4,7 @@ from circus.util import DEFAULT_ENDPOINT_MULTICAST
 from circus import logger
 import circus.controller
 
-import mock
+from unittest import mock
 
 
 class TestController(TestCase):

--- a/circus/tests/test_plugin_command_reloader.py
+++ b/circus/tests/test_plugin_command_reloader.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from circus.plugins.command_reloader import CommandReloader
 from circus.tests.support import TestCircus, EasyTestSuite

--- a/circus/tests/test_plugin_flapping.py
+++ b/circus/tests/test_plugin_flapping.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.plugins.flapping import Flapping

--- a/circus/tests/test_sockets.py
+++ b/circus/tests/test_sockets.py
@@ -5,7 +5,7 @@ try:
     import IN
 except ImportError:
     pass
-import mock
+from unittest import mock
 import fcntl
 
 from circus.tests.support import TestCase, skipIf, EasyTestSuite, IS_WINDOWS

--- a/circus/tests/test_stats_publisher.py
+++ b/circus/tests/test_stats_publisher.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import zmq
 import zmq.utils.jsonapi as json

--- a/circus/tests/test_stats_streamer.py
+++ b/circus/tests/test_stats_streamer.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-import mock
+from unittest import mock
 
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.stats.streamer import StatsStreamer

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -13,7 +13,7 @@ except ImportError:
 
 import psutil
 from psutil import Popen
-import mock
+from unittest import mock
 
 from circus.tests.support import (TestCase, EasyTestSuite, skipIf,
                                   IS_WINDOWS, SLEEP)

--- a/circus/tests/test_validate_option.py
+++ b/circus/tests/test_validate_option.py
@@ -1,5 +1,5 @@
 from circus.tests.support import TestCase, EasyTestSuite, IS_WINDOWS
-from mock import patch
+from unittest.mock import patch
 
 from circus.commands.util import validate_option
 from circus.exc import MessageError

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -16,7 +16,7 @@ except ImportError:
         captured_output = None  # NOQA
 
 import tornado
-import mock
+from unittest import mock
 
 from circus import logger
 from circus.process import RUNNING, UNEXISTING


### PR DESCRIPTION
For py>3.5 `mock` package in combined into unittest as `unittest.mock`.